### PR TITLE
OPENEUROPA-1426: Editorial workflow: Change "Edit" to "New draft" if the content is in Published state.

### DIFF
--- a/modules/oe_editorial_corporate_workflow/oe_editorial_corporate_workflow.module
+++ b/modules/oe_editorial_corporate_workflow/oe_editorial_corporate_workflow.module
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * @file
+ * OpenEuropa Editorial module.
+ */
+
+declare(strict_types = 1);
+
+use Drupal\node\NodeInterface;
+
+/**
+ * Implements hook_menu_local_tasks_alter().
+ */
+function oe_editorial_corporate_workflow_menu_local_tasks_alter(&$data): void {
+  $node = \Drupal::routeMatch()->getParameter('node');
+  if ($node instanceof NodeInterface && !empty($data['tabs'][0]['entity.node.edit_form']['#link'])) {
+    /** @var \Drupal\content_moderation\ModerationInformationInterface $moderation_information */
+    $moderation_information = \Drupal::service('content_moderation.moderation_information');
+    if ($moderation_information->isModeratedEntity($node) &&
+      $moderation_information->isModeratedEntity($node) &&
+      $moderation_information->isDefaultRevisionPublished($node)) {
+      if (!$moderation_information->hasPendingRevision($node)) {
+        $data['tabs'][0]['entity.node.edit_form']['#link']['title'] = t('New draft');
+      }
+      else {
+        $data['tabs'][0]['entity.node.edit_form']['#link']['title'] = t('Edit draft');
+      }
+    }
+  }
+}

--- a/modules/oe_editorial_corporate_workflow/oe_editorial_corporate_workflow.module
+++ b/modules/oe_editorial_corporate_workflow/oe_editorial_corporate_workflow.module
@@ -18,13 +18,12 @@ function oe_editorial_corporate_workflow_menu_local_tasks_alter(&$data): void {
     /** @var \Drupal\content_moderation\ModerationInformationInterface $moderation_information */
     $moderation_information = \Drupal::service('content_moderation.moderation_information');
     if ($moderation_information->isModeratedEntity($node) &&
-      $moderation_information->isModeratedEntity($node) &&
       $moderation_information->isDefaultRevisionPublished($node)) {
-      if (!$moderation_information->hasPendingRevision($node)) {
-        $data['tabs'][0]['entity.node.edit_form']['#link']['title'] = t('New draft');
+      if ($moderation_information->hasPendingRevision($node)) {
+        $data['tabs'][0]['entity.node.edit_form']['#link']['title'] = t('Edit draft');
       }
       else {
-        $data['tabs'][0]['entity.node.edit_form']['#link']['title'] = t('Edit draft');
+        $data['tabs'][0]['entity.node.edit_form']['#link']['title'] = t('New draft');
       }
     }
   }

--- a/modules/oe_editorial_corporate_workflow/oe_editorial_corporate_workflow.module
+++ b/modules/oe_editorial_corporate_workflow/oe_editorial_corporate_workflow.module
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * OpenEuropa Editorial module.
+ * OpenEuropa Editorial Corporate Workflow module.
  */
 
 declare(strict_types = 1);

--- a/tests/features/editorial_workflow.feature
+++ b/tests/features/editorial_workflow.feature
@@ -70,7 +70,7 @@ Feature: Corporate editorial workflow
       | Published |
     When I select "Published" from "Change to"
     And I press "Save"
-    And I click "Edit"
+    And I click "New draft"
     Then the current workflow state should be "Published"
 
   Scenario: As an Author user, I can Publish a Validated demo content.
@@ -92,11 +92,35 @@ Feature: Corporate editorial workflow
       | Published |
     When I select "Published" from "Change to"
     And I press "Save"
-    And I click "Edit"
+    And I click "New draft"
     # After Publish I can restart the workflow.
     Then I should have the following options for the "Change to" select:
       | Draft |
     Then the current workflow state should be "Published"
+    When I visit "admin/content"
+    # The content is created and it is published.
+    Then I should see text matching "published"
+    And I should not see text matching "not published"
+
+  Scenario: As an Author user, I can create new draft for published content.
+    Given users:
+      | name        | roles  |
+      | author_user | Author |
+    And "oe_workflow_demo" content:
+      | title         | moderation_state | author      |
+      | Workflow node | published        | author_user |
+    And I am logged in as "author_user"
+    When I visit "admin/content"
+    # The content is created and it is published.
+    Then I should see the text "published" in the "Workflow node" row
+    When I click "Workflow node"
+    And I click "New draft"
+     # After Publish I can restart the workflow.
+    Then I should have the following options for the "Change to" select:
+      | Draft     |
+    When I select "Draft" from "Change to"
+    And I press "Save"
+    And I should see "Edit draft"
     When I visit "admin/content"
     # The content is created and it is published.
     Then I should see text matching "published"


### PR DESCRIPTION
## OPENEUROPA-1426

### Description
Now if the node is in Published state the Edit tab is miss leading for Editors because if they Edit and save as Draft they will end up creating a new draft.

Change the "Edit" string to "New draft" on node tab if the node is in state: Published and the node has no new revisions made after the Published state.
Change "Edit" to "Edit draft" if the node is in state: Published and has a new revision created already that is not in published state (Draft, Needs Review, Request Validation, Validated).