### PR TITLE
OPENEUROPA-1609 Fix behat.yml.dist to use drupal-extension properly.

### DIFF
--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -12,7 +12,7 @@ default:
               demo content creation: 'node/add/oe_workflow_demo'
               content administration: 'admin/content'
   extensions:
-    Behat\MinkExtension:
+    Drupal\MinkExtension:
       goutte: ~
       selenium2: ~
       javascript_session: selenium2

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "drupal-composer/drupal-scaffold": "~2.2",
         "drupal/config_devel": "~1.2",
         "drupal/console": "~1.0",
-        "drupal/drupal-extension": "~4.0.0@beta",
+        "drupal/drupal-extension": "~4.0",
         "drush/drush": "~9.0@stable",
         "nikic/php-parser": "~3.0",
         "openeuropa/behat-transformation-context" : "~0.1",


### PR DESCRIPTION
After moving from drupal-extension v3 to v4 Drupal\MinkExtension has to be used.