### PR TITLE
OPENEUROPA-2053: Corporate workflow translation.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,8 +6,8 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "drupal/core": "^8.7",
-        "php": "^7.1"
+        "php": "^7.1",
+        "drupal/core": "^8.7"
     },
     "require-dev": {
         "composer/installers": "~1.5",
@@ -25,7 +25,8 @@
         "phpunit/phpunit": "~6.0",
         "symfony/browser-kit": "~4.2.1",
         "squizlabs/php_codesniffer": "~3.3.2",
-        "openeuropa/entity_version": "~1.0.0-beta1"
+        "openeuropa/entity_version": "~1.0.0-beta1",
+        "openeuropa/oe_translation": "dev-OPENEUROPA-2053"
     },
     "scripts": {
         "drupal-scaffold": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold",

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "symfony/browser-kit": "~4.2.1",
         "squizlabs/php_codesniffer": "~3.3.2",
         "openeuropa/entity_version": "~1.0.0-beta1",
-        "openeuropa/oe_translation": "dev-OPENEUROPA-2053"
+        "openeuropa/oe_translation": "~0.1"
     },
     "scripts": {
         "drupal-scaffold": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold",

--- a/modules/oe_editorial_corporate_workflow/modules/oe_editorial_corporate_workflow_translation/README.md
+++ b/modules/oe_editorial_corporate_workflow/modules/oe_editorial_corporate_workflow_translation/README.md
@@ -1,0 +1,5 @@
+# OpenEuropa Corporate Editorial Workflow Translation
+
+This module integrates the corporate workflow with the [OpenEuropa Translation](https://github.com/openeuropa/oe_translation) component.
+
+Content becomes translatable as soon as it hits the Validated state.

--- a/modules/oe_editorial_corporate_workflow/modules/oe_editorial_corporate_workflow_translation/oe_editorial_corporate_workflow_translation.info.yml
+++ b/modules/oe_editorial_corporate_workflow/modules/oe_editorial_corporate_workflow_translation/oe_editorial_corporate_workflow_translation.info.yml
@@ -1,0 +1,10 @@
+name: OpenEuropa Editorial Corporate Workflow Translation
+description: Integrates the editorial workflow with OE Translation
+package: OpenEuropa
+type: module
+core: 8.x
+
+dependencies:
+  - oe_editorial_corporate_workflow:oe_editorial_corporate_workflow
+  - oe_translation:oe_translation
+  - oe_editorial_entity_version:oe_editorial_entity_version

--- a/modules/oe_editorial_corporate_workflow/modules/oe_editorial_corporate_workflow_translation/oe_editorial_corporate_workflow_translation.install
+++ b/modules/oe_editorial_corporate_workflow/modules/oe_editorial_corporate_workflow_translation/oe_editorial_corporate_workflow_translation.install
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * @file
+ * OpenEuropa Editorial Corporate Workflow Translation install file.
+ */
+
+declare(strict_types = 1);
+
+/**
+ * Implements hook_install().
+ */
+function oe_editorial_corporate_workflow_translation_install() {
+  // The OpenEuropa Translation module ships with a "Translator" role which has
+  // the necessary permissions to perform translations. We need to take those
+  // permissions and assign them to the Translator role provided by the
+  // Editorial component and delete the role.
+  /** @var \Drupal\user\RoleInterface $translator */
+  $translator = \Drupal::entityTypeManager()->getStorage('user_role')->load('translator');
+  /** @var \Drupal\user\RoleInterface $oe_translator */
+  $oe_translator = \Drupal::entityTypeManager()->getStorage('user_role')->load('oe_translator');
+  if ($translator && $oe_translator) {
+    foreach ($translator->getPermissions() as $permission) {
+      $oe_translator->grantPermission($permission);
+    }
+    $oe_translator->save();
+    $translator->delete();
+  }
+}

--- a/modules/oe_editorial_corporate_workflow/modules/oe_editorial_corporate_workflow_translation/oe_editorial_corporate_workflow_translation.module
+++ b/modules/oe_editorial_corporate_workflow/modules/oe_editorial_corporate_workflow_translation/oe_editorial_corporate_workflow_translation.module
@@ -85,51 +85,53 @@ function oe_editorial_corporate_workflow_translation_node_view_alter(array &$bui
  * @see CorporateWorkflowTranslationRevisionTest::testTranslationRevisions()
  */
 function oe_editorial_corporate_workflow_translation_node_revision_create(ContentEntityInterface $revision, ContentEntityInterface $entity, $original_keep_untranslatable_fields): void {
-  if (!$entity->isNew() && !$entity->isDefaultRevision() && $entity->isTranslatable() && $entity->getTranslationLanguages(FALSE)) {
-    // Create a new revision from the entity so that we can get the correct
-    // translation field values from. Other than that, we are working with the
-    // $revision that was created in the storage handler as the latter also
-    // did extra things on it which we need to keep.
-    $new_revision = clone $entity;
-    $active_langcode = $entity->language()->getId();
-
-    /** @var \Drupal\Core\Entity\ContentEntityTypeInterface $entity_type */
-    $entity_type = $entity->getEntityType();
-
-    // A list of known revision metadata fields which should be skipped from
-    // the comparision.
-    $skipped_field_names = [
-      $entity_type->getKey('revision'),
-      $entity_type->getKey('revision_translation_affected'),
-    ];
-    $skipped_field_names = array_merge($skipped_field_names, array_values($entity_type->getRevisionMetadataKeys()));
-    $skipped_field_names = array_flip($skipped_field_names);
-
-    if (!isset($keep_untranslatable_fields)) {
-      $keep_untranslatable_fields = $entity->isDefaultTranslation() && $entity->isDefaultTranslationAffectedOnly();
-    }
-
-    /** @var \Drupal\Core\Entity\ContentEntityInterface $default_revision */
-    $default_revision = \Drupal::entityTypeManager()->getStorage($entity->getEntityTypeId())->load($entity->id());
-    $translation_languages = $default_revision->getTranslationLanguages();
-    foreach ($translation_languages as $langcode => $language) {
-      if ($langcode == $active_langcode) {
-        continue;
-      }
-
-      $revision_translation = $revision->hasTranslation($langcode) ? $revision->getTranslation($langcode) : $revision->addTranslation($langcode);
-      $new_revision_translation = $new_revision->hasTranslation($langcode) ? $new_revision->getTranslation($langcode) : $new_revision->addTranslation($langcode);
-
-      /** @var \Drupal\Core\Field\FieldItemListInterface[] $sync_items */
-      $sync_items = array_diff_key(
-        $keep_untranslatable_fields ? $new_revision_translation->getTranslatableFields() : $new_revision_translation->getFields(),
-        $skipped_field_names
-      );
-      foreach ($sync_items as $field_name => $items) {
-        $revision_translation->set($field_name, $items->getValue());
-      }
-    }
-
-    $revision->original = clone $revision;
+  if ($entity->isNew() || $entity->isDefaultRevision() || !$entity->isTranslatable() || !$entity->getTranslationLanguages(FALSE)) {
+    return;
   }
+
+  // Create a new revision from the entity so that we can get the correct
+  // translation field values from. Other than that, we are working with the
+  // $revision that was created in the storage handler as the latter also
+  // did extra things on it which we need to keep.
+  $new_revision = clone $entity;
+  $active_langcode = $entity->language()->getId();
+
+  /** @var \Drupal\Core\Entity\ContentEntityTypeInterface $entity_type */
+  $entity_type = $entity->getEntityType();
+
+  // A list of known revision metadata fields which should be skipped from
+  // the comparision.
+  $skipped_field_names = [
+    $entity_type->getKey('revision'),
+    $entity_type->getKey('revision_translation_affected'),
+  ];
+  $skipped_field_names = array_merge($skipped_field_names, array_values($entity_type->getRevisionMetadataKeys()));
+  $skipped_field_names = array_flip($skipped_field_names);
+
+  if (!isset($keep_untranslatable_fields)) {
+    $keep_untranslatable_fields = $entity->isDefaultTranslation() && $entity->isDefaultTranslationAffectedOnly();
+  }
+
+  /** @var \Drupal\Core\Entity\ContentEntityInterface $default_revision */
+  $default_revision = \Drupal::entityTypeManager()->getStorage($entity->getEntityTypeId())->load($entity->id());
+  $translation_languages = $default_revision->getTranslationLanguages();
+  foreach ($translation_languages as $langcode => $language) {
+    if ($langcode == $active_langcode) {
+      continue;
+    }
+
+    $revision_translation = $revision->hasTranslation($langcode) ? $revision->getTranslation($langcode) : $revision->addTranslation($langcode);
+    $new_revision_translation = $new_revision->hasTranslation($langcode) ? $new_revision->getTranslation($langcode) : $new_revision->addTranslation($langcode);
+
+    /** @var \Drupal\Core\Field\FieldItemListInterface[] $sync_items */
+    $sync_items = array_diff_key(
+      $keep_untranslatable_fields ? $new_revision_translation->getTranslatableFields() : $new_revision_translation->getFields(),
+      $skipped_field_names
+    );
+    foreach ($sync_items as $field_name => $items) {
+      $revision_translation->set($field_name, $items->getValue());
+    }
+  }
+
+  $revision->original = clone $revision;
 }

--- a/modules/oe_editorial_corporate_workflow/modules/oe_editorial_corporate_workflow_translation/oe_editorial_corporate_workflow_translation.module
+++ b/modules/oe_editorial_corporate_workflow/modules/oe_editorial_corporate_workflow_translation/oe_editorial_corporate_workflow_translation.module
@@ -7,13 +7,14 @@
 
 declare(strict_types = 1);
 
+use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
 use Drupal\Core\Entity\EntityInterface;
 
 /**
  * Implements hook_ENTITY_TYPE_presave().
  */
-function oe_editorial_corporate_workflow_translation_node_presave(EntityInterface $entity) {
+function oe_editorial_corporate_workflow_translation_node_presave(EntityInterface $entity): void {
   // Whenever we save a translation, we need to ensure that we maintain its
   // status the same as the source. This is the default behaviour for "synced"
   // translations. Later, we will introduce the "un-synced" translations by
@@ -24,7 +25,7 @@ function oe_editorial_corporate_workflow_translation_node_presave(EntityInterfac
     // translation for the correct status.
     $source = $entity->getUntranslated();
     if ($source->get('status')->value !== $entity->get('status')->value) {
-      $entity->set('status', $source->get('status'));
+      $entity->set('status', $source->get('status')->value);
     }
 
     return;
@@ -47,7 +48,7 @@ function oe_editorial_corporate_workflow_translation_node_presave(EntityInterfac
 /**
  * Implements hook_ENTITY_TYPE_view_alter() for the Node entity.
  */
-function oe_editorial_corporate_workflow_translation_node_view_alter(array &$build, EntityInterface $entity, EntityViewDisplayInterface $display) {
+function oe_editorial_corporate_workflow_translation_node_view_alter(array &$build, EntityInterface $entity, EntityViewDisplayInterface $display): void {
   // If we are rendering a translation, we should hide the content moderation
   // block because the workflow needs to be controlled from the source entity.
   if ($entity->isDefaultTranslation()) {
@@ -56,5 +57,79 @@ function oe_editorial_corporate_workflow_translation_node_view_alter(array &$bui
 
   if (isset($build['content_moderation_control'])) {
     $build['content_moderation_control']['#access'] = FALSE;
+  }
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_revision_create() for the Node entity.
+ *
+ * This hook replicates to an extent a chunk of the responsibility of
+ * ContentEntityStorageBase::create().
+ *
+ * The purpose is to ensure that whenever we create a new revision of a content
+ * entity that is translatable, for each translation language we carry over
+ * the translation values from the revision based on which we make the new
+ * revision.
+ *
+ * By default, if the entity has a previous revision that is marked as
+ * default (such as published), any new revision on the entity which is not
+ * default will carry over translations from that last default revision instead
+ * of the actual revision based on which the new one is created. For us this is
+ * not good because we use TMGMT to hydrate specific revisions with translations
+ * regardless of whether they are default or not. So for example, if revision 5
+ * is not published but has a translation, when we make revision 6 to publish
+ * it, we carry over the translation values from revision 5 and not from any
+ * previous ones which might have been marked as default (previous published
+ * versions).
+ *
+ * @see CorporateWorkflowTranslationRevisionTest::testTranslationRevisions()
+ */
+function oe_editorial_corporate_workflow_translation_node_revision_create(ContentEntityInterface $revision, ContentEntityInterface $entity, $original_keep_untranslatable_fields): void {
+  if (!$entity->isNew() && !$entity->isDefaultRevision() && $entity->isTranslatable() && $entity->getTranslationLanguages(FALSE)) {
+    // Create a new revision from the entity so that we can get the correct
+    // translation field values from. Other than that, we are working with the
+    // $revision that was created in the storage handler as the latter also
+    // did extra things on it which we need to keep.
+    $new_revision = clone $entity;
+    $active_langcode = $entity->language()->getId();
+
+    /** @var \Drupal\Core\Entity\ContentEntityTypeInterface $entity_type */
+    $entity_type = $entity->getEntityType();
+
+    // A list of known revision metadata fields which should be skipped from
+    // the comparision.
+    $skipped_field_names = [
+      $entity_type->getKey('revision'),
+      $entity_type->getKey('revision_translation_affected'),
+    ];
+    $skipped_field_names = array_merge($skipped_field_names, array_values($entity_type->getRevisionMetadataKeys()));
+    $skipped_field_names = array_flip($skipped_field_names);
+
+    if (!isset($keep_untranslatable_fields)) {
+      $keep_untranslatable_fields = $entity->isDefaultTranslation() && $entity->isDefaultTranslationAffectedOnly();
+    }
+
+    /** @var \Drupal\Core\Entity\ContentEntityInterface $default_revision */
+    $default_revision = \Drupal::entityTypeManager()->getStorage($entity->getEntityTypeId())->load($entity->id());
+    $translation_languages = $default_revision->getTranslationLanguages();
+    foreach ($translation_languages as $langcode => $language) {
+      if ($langcode == $active_langcode) {
+        continue;
+      }
+
+      $revision_translation = $revision->hasTranslation($langcode) ? $revision->getTranslation($langcode) : $revision->addTranslation($langcode);
+      $new_revision_translation = $new_revision->hasTranslation($langcode) ? $new_revision->getTranslation($langcode) : $new_revision->addTranslation($langcode);
+
+      /** @var \Drupal\Core\Field\FieldItemListInterface[] $sync_items */
+      $sync_items = array_diff_key(
+        $keep_untranslatable_fields ? $new_revision_translation->getTranslatableFields() : $new_revision_translation->getFields(),
+        $skipped_field_names
+      );
+      foreach ($sync_items as $field_name => $items) {
+        $revision_translation->set($field_name, $items->getValue());
+      }
+    }
+
+    $revision->original = clone $revision;
   }
 }

--- a/modules/oe_editorial_corporate_workflow/modules/oe_editorial_corporate_workflow_translation/oe_editorial_corporate_workflow_translation.module
+++ b/modules/oe_editorial_corporate_workflow/modules/oe_editorial_corporate_workflow_translation/oe_editorial_corporate_workflow_translation.module
@@ -7,6 +7,7 @@
 
 declare(strict_types = 1);
 
+use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
 use Drupal\Core\Entity\EntityInterface;
 
 /**
@@ -35,10 +36,25 @@ function oe_editorial_corporate_workflow_translation_node_presave(EntityInterfac
   foreach ($languages as $language) {
     $translation = $entity->getTranslation($language->getId());
     if ($translation->get('status')->value !== $entity->get('status')->value) {
-      $translation->set('status', $entity->get('status'));
+      $translation->set('status', $entity->get('status')->value);
     }
   }
 
   // @todo, when introducing the "un-synced" translations, we need to apply
   // a check to determine whether the entity status stays synced.
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_view_alter() for the Node entity.
+ */
+function oe_editorial_corporate_workflow_translation_node_view_alter(array &$build, EntityInterface $entity, EntityViewDisplayInterface $display) {
+  // If we are rendering a translation, we should hide the content moderation
+  // block because the workflow needs to be controlled from the source entity.
+  if ($entity->isDefaultTranslation()) {
+    return;
+  }
+
+  if (isset($build['content_moderation_control'])) {
+    $build['content_moderation_control']['#access'] = FALSE;
+  }
 }

--- a/modules/oe_editorial_corporate_workflow/modules/oe_editorial_corporate_workflow_translation/oe_editorial_corporate_workflow_translation.module
+++ b/modules/oe_editorial_corporate_workflow/modules/oe_editorial_corporate_workflow_translation/oe_editorial_corporate_workflow_translation.module
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * @file
+ * OpenEuropa Editorial Corporate Workflow Translation module file.
+ */
+
+declare(strict_types = 1);
+
+use Drupal\Core\Entity\EntityInterface;
+
+/**
+ * Implements hook_ENTITY_TYPE_presave().
+ */
+function oe_editorial_corporate_workflow_translation_node_presave(EntityInterface $entity) {
+  // Whenever we save a translation, we need to ensure that we maintain its
+  // status the same as the source. This is the default behaviour for "synced"
+  // translations. Later, we will introduce the "un-synced" translations by
+  // which we will keep the translations unpublished even if the source language
+  // is published.
+  if (!$entity->isDefaultTranslation()) {
+    // If we are saving a translation entity directly, look at the source
+    // translation for the correct status.
+    $source = $entity->getUntranslated();
+    if ($source->get('status')->value !== $entity->get('status')->value) {
+      $entity->set('status', $source->get('status'));
+    }
+
+    return;
+  }
+
+  // Otherwise, loop through all the translations and set the status based on
+  // the source.
+  $languages = $entity->getTranslationLanguages(FALSE);
+  foreach ($languages as $language) {
+    $translation = $entity->getTranslation($language->getId());
+    if ($translation->get('status')->value !== $entity->get('status')->value) {
+      $translation->set('status', $entity->get('status'));
+    }
+  }
+
+  // @todo, when introducing the "un-synced" translations, we need to apply
+  // a check to determine whether the entity status stays synced.
+}

--- a/modules/oe_editorial_corporate_workflow/modules/oe_editorial_corporate_workflow_translation/oe_editorial_corporate_workflow_translation.services.yml
+++ b/modules/oe_editorial_corporate_workflow/modules/oe_editorial_corporate_workflow_translation/oe_editorial_corporate_workflow_translation.services.yml
@@ -1,0 +1,11 @@
+services:
+  oe_editorial_corporate_workflow_translation.translation_access_subscriber:
+    class: Drupal\oe_editorial_corporate_workflow_translation\EventSubscriber\TranslationAccessSubscriber
+    arguments: ['@content_moderation.moderation_information', '@entity_type.manager']
+    tags:
+      - { name: event_subscriber }
+  oe_editorial_corporate_workflow_translation.entity_source_subscriber:
+    class: Drupal\oe_editorial_corporate_workflow_translation\EventSubscriber\CorporateWorkflowEntitySourceSubscriber
+    arguments: ['@entity_type.manager', '@content_moderation.moderation_information']
+    tags:
+      - { name: event_subscriber }

--- a/modules/oe_editorial_corporate_workflow/modules/oe_editorial_corporate_workflow_translation/src/EventSubscriber/CorporateWorkflowEntitySourceSubscriber.php
+++ b/modules/oe_editorial_corporate_workflow/modules/oe_editorial_corporate_workflow_translation/src/EventSubscriber/CorporateWorkflowEntitySourceSubscriber.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\oe_editorial_corporate_workflow_translation\EventSubscriber;
+
+use Drupal\content_moderation\ModerationInformationInterface;
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\oe_translation\Event\ContentEntitySourceEntityEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Provides the entity revision onto which the translation should be saved.
+ *
+ * When content uses the corporate workflow, the translations need to be saved
+ * onto the same major version, in the latest revision made as part of that
+ * major version.
+ */
+class CorporateWorkflowEntitySourceSubscriber implements EventSubscriberInterface {
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * The moderation information.
+   *
+   * @var \Drupal\content_moderation\ModerationInformationInterface
+   */
+  protected $moderationInformation;
+
+  /**
+   * DefaultContentEntitySourceEntitySubscriber constructor.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   *   The entity type manager.
+   * @param \Drupal\content_moderation\ModerationInformationInterface $moderationInformation
+   *   The moderation information.
+   */
+  public function __construct(EntityTypeManagerInterface $entityTypeManager, ModerationInformationInterface $moderationInformation) {
+    $this->entityTypeManager = $entityTypeManager;
+    $this->moderationInformation = $moderationInformation;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    return [
+      ContentEntitySourceEntityEvent::EVENT => ['getEntity', 0],
+    ];
+  }
+
+  /**
+   * Returns the correct entity revision.
+   *
+   * @param \Drupal\oe_translation\Event\ContentEntitySourceEntityEvent $event
+   *   The event.
+   *
+   * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+   * @SuppressWarnings(PHPMD.NPathComplexity)
+   */
+  public function getEntity(ContentEntitySourceEntityEvent $event): void {
+    $job_item = $event->getJobItem();
+    if (!$job_item->hasField('item_rid') || $job_item->get('item_rid')->isEmpty()) {
+      // We must have the bundle and revision ID.
+      return;
+    }
+
+    /** @var \Drupal\Core\Entity\ContentEntityInterface $entity */
+    $entity = $this->entityTypeManager->getStorage($job_item->getItemType())->loadRevision($job_item->get('item_rid')->value);
+    // If the entity was deleted, do thing.
+    if (!$entity instanceof ContentEntityInterface) {
+      return;
+    }
+
+    /** @var \Drupal\workflows\WorkflowInterface $workflow */
+    $workflow = $this->moderationInformation->getWorkflowForEntity($entity);
+    if (!$workflow || $workflow->id() !== 'oe_corporate_workflow') {
+      // We only care about the entities moderated using the corporate
+      // workflow.
+      return;
+    }
+
+    if (!$entity->hasField('version') || $entity->get('version')->isEmpty()) {
+      // We rely on the corporate workflow entity version field.
+      return;
+    }
+
+    /** @var \Drupal\entity_version\Plugin\Field\FieldType\EntityVersionItem $original_version */
+    $original_version = $entity->get('version')->first();
+    $original_major = $original_version->get('major')->getValue();
+    $original_minor = $original_version->get('minor')->getValue();
+
+    // Load the latest revision of the same entity that has the same major and
+    // minor version. This is in case the entity is published since it was
+    // validated to ensure we save the translation onto that version.
+    $results = $this->entityTypeManager->getStorage($entity->getEntityTypeId())->getQuery()
+      ->condition($entity->getEntityType()->getKey('id'), $entity->id())
+      ->condition('version.major', $original_major)
+      ->condition('version.minor', $original_minor)
+      ->accessCheck(FALSE)
+      ->allRevisions()
+      ->execute();
+
+    end($results);
+    $vid = key($results);
+    /** @var \Drupal\Core\Entity\ContentEntityInterface $entity */
+    $entity = $this->entityTypeManager->getStorage($entity->getEntityTypeId())->loadRevision($vid);
+
+    if (!$entity->hasTranslation($job_item->getJob()->getTargetLangcode())) {
+      // We create the empty translation on the entity so that we ensure if we
+      // need to set the entity to not be the default revision (see below), it
+      // doesn't get later overridden in
+      // ContentEntitySource::doSaveTranslations().
+      $entity->addTranslation($job_item->getJob()->getTargetLangcode(), $entity->toArray());
+    }
+
+    // Check if the entity has a forward revision that is published and mark
+    // the revision as not the default if any are found. This is needed because
+    // it means the translation is being saved on a older version and we need to
+    // make sure Drupal doesn't turn this revision into the current one.
+    $has_forward_published = $this->entityTypeManager->getStorage($entity->getEntityTypeId())->getQuery()
+      ->condition($entity->getEntityType()->getKey('id'), $entity->id())
+      ->condition($entity->getEntityType()->getKey('revision'), $vid, '>')
+      ->condition($entity->getEntityType()->getKey('status'), TRUE)
+      ->accessCheck(FALSE)
+      ->allRevisions()
+      ->execute();
+
+    if (!empty($has_forward_published)) {
+      $entity->isDefaultRevision(FALSE);
+    }
+
+    $event->setEntity($entity);
+    $event->stopPropagation();
+  }
+
+}

--- a/modules/oe_editorial_corporate_workflow/modules/oe_editorial_corporate_workflow_translation/src/EventSubscriber/CorporateWorkflowEntitySourceSubscriber.php
+++ b/modules/oe_editorial_corporate_workflow/modules/oe_editorial_corporate_workflow_translation/src/EventSubscriber/CorporateWorkflowEntitySourceSubscriber.php
@@ -73,7 +73,7 @@ class CorporateWorkflowEntitySourceSubscriber implements EventSubscriberInterfac
 
     /** @var \Drupal\Core\Entity\ContentEntityInterface $entity */
     $entity = $this->entityTypeManager->getStorage($job_item->getItemType())->loadRevision($job_item->get('item_rid')->value);
-    // If the entity was deleted, do thing.
+    // If the entity was deleted, do nothing.
     if (!$entity instanceof ContentEntityInterface) {
       return;
     }

--- a/modules/oe_editorial_corporate_workflow/modules/oe_editorial_corporate_workflow_translation/src/EventSubscriber/TranslationAccessSubscriber.php
+++ b/modules/oe_editorial_corporate_workflow/modules/oe_editorial_corporate_workflow_translation/src/EventSubscriber/TranslationAccessSubscriber.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\oe_editorial_corporate_workflow_translation\EventSubscriber;
+
+use Drupal\content_moderation\ModerationInformationInterface;
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\oe_translation\Event\TranslationAccessEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Determines access to create new translations based on the corporate workflow.
+ */
+class TranslationAccessSubscriber implements EventSubscriberInterface {
+
+  /**
+   * The moderation info.
+   *
+   * @var \Drupal\content_moderation\ModerationInformationInterface
+   */
+  protected $moderationInformation;
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * TranslationAccessSubscriber constructor.
+   *
+   * @param \Drupal\content_moderation\ModerationInformationInterface $moderationInformation
+   *   The moderation info.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   *   The entity type manager.
+   */
+  public function __construct(ModerationInformationInterface $moderationInformation, EntityTypeManagerInterface $entityTypeManager) {
+    $this->moderationInformation = $moderationInformation;
+    $this->entityTypeManager = $entityTypeManager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    return [
+      TranslationAccessEvent::EVENT => 'access',
+    ];
+  }
+
+  /**
+   * Callback to control the access.
+   *
+   * Entities using the corporate workflow can only be translated in validated.
+   *
+   * @param \Drupal\oe_translation\Event\TranslationAccessEvent $event
+   *   The event.
+   */
+  public function access(TranslationAccessEvent $event) {
+    $entity = $event->getEntity();
+    /** @var \Drupal\workflows\WorkflowInterface $workflow */
+    $workflow = $this->moderationInformation->getWorkflowForEntity($entity);
+    if (!$workflow || $workflow->id() !== 'oe_corporate_workflow') {
+      return;
+    }
+
+    if (!$entity->isLatestRevision()) {
+      // We only allow access if the latest entity revision qualifies below.
+      $storage = $this->entityTypeManager->getStorage($entity->getEntityTypeId());
+      $entity = $storage->loadRevision($storage->getLatestRevisionId($entity->id()));
+    }
+
+    // Content can only be translated when reaching the validated state.
+    $state = $entity->get('moderation_state')->value;
+    if (!in_array($state, ['validated', 'published'])) {
+      $event->setAccess(AccessResult::forbidden());
+      return;
+    }
+  }
+
+}

--- a/modules/oe_editorial_corporate_workflow/modules/oe_editorial_corporate_workflow_translation/tests/Functional/CorporateWorkflowTranslationTest.php
+++ b/modules/oe_editorial_corporate_workflow/modules/oe_editorial_corporate_workflow_translation/tests/Functional/CorporateWorkflowTranslationTest.php
@@ -1,0 +1,334 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\oe_editorial_corporate_workflow_translation\Functional;
+
+use Drupal\Core\Config\FileStorage;
+use Drupal\Core\Url;
+use Drupal\node\NodeInterface;
+use Drupal\Tests\BrowserTestBase;
+
+/**
+ * Tests the translation revision capability.
+ *
+ * Using the corporate editorial workflow, translations need to be saved onto
+ * the latest revision of the entity's major version. In other words, if the
+ * translation is started when the entity is in validated state (the minimum),
+ * and the entity gets published before the translation comes back, the latter
+ * should be saved on the published revision. But not on any future drafts
+ * which create new minor versions.
+ */
+class CorporateWorkflowTranslationRevisionTest extends BrowserTestBase {
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * The current user.
+   *
+   * @var \Drupal\user\UserInterface
+   */
+  protected $user;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'tmgmt',
+    'tmgmt_local',
+    'tmgmt_content',
+    'node',
+    'toolbar',
+    'content_translation',
+    'user',
+    'field',
+    'text',
+    'options',
+    'oe_editorial_workflow_demo',
+    'oe_translation',
+    'oe_editorial_corporate_workflow_translation',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setUp() {
+    parent::setUp();
+
+    $this->entityTypeManager = $this->container->get('entity_type.manager');
+
+    $this->entityTypeManager->getStorage('node_type')->create([
+      'name' => 'Page',
+      'type' => 'page',
+    ])->save();
+
+    $this->container->get('content_translation.manager')->setEnabled('node', 'page', TRUE);
+    $this->container->get('oe_editorial_corporate_workflow.workflow_installer')->installWorkflow('page');
+    $default_values = [
+      'major' => 0,
+      'minor' => 1,
+      'patch' => 0,
+    ];
+    $this->container->get('entity_version.entity_version_installer')->install('node', ['page'], $default_values);
+    $this->container->get('router.builder')->rebuild();
+
+    /** @var \Drupal\user\RoleInterface $role */
+    $role = $this->entityTypeManager->getStorage('user_role')->load('oe_translator');
+    $this->user = $this->drupalCreateUser($role->getPermissions());
+
+    $this->drupalLogin($this->user);
+  }
+
+  /**
+   * Tests that the Translator roles get merged.
+   *
+   * Checks that the translator role shipped by the OpenEuropa Editorial
+   * component inherits the permissions of the one shipped by the OpenEuropa
+   * Translation one and the latter is deleted.
+   */
+  public function testRoleMerge(): void {
+    $storage = new FileStorage(drupal_get_path('module', 'oe_translation') . '/config/install');
+    $values = $storage->read('user.role.translator');
+    $permissions = $values['permissions'];
+
+    /** @var \Drupal\user\RoleInterface $role */
+    $role = $this->entityTypeManager->getStorage('user_role')->load('oe_translator');
+    foreach ($permissions as $permission) {
+      $this->assertTrue($role->hasPermission($permission), 'The OE Translator role is missing a permission');
+    }
+
+    $this->assertEmpty($this->entityTypeManager->getStorage('user_role')->load($values['id']));
+  }
+
+  /**
+   * Tests that users can only create translations of validated content.
+   */
+  public function testTranslationAccess(): void {
+    /** @var \Drupal\node\NodeStorageInterface $node_storage */
+    $node_storage = $this->entityTypeManager->getStorage('node');
+
+    /** @var \Drupal\node\NodeInterface $node */
+    $node = $node_storage->create([
+      'type' => 'page',
+      'title' => 'My node',
+      'moderation_state' => 'draft',
+    ]);
+    $node->save();
+
+    // Ensure we can only create translation task if the node is validated or
+    // published.
+    $local_task_creation_url = Url::fromRoute('oe_translation.permission_translator.create_local_task', [
+      'entity' => $node->id(),
+      'source' => 'en',
+      'target' => 'fr',
+      'entity_type' => 'node',
+    ]);
+    $this->assertFalse($local_task_creation_url->access($this->user));
+
+    $node->set('moderation_state', 'needs_review');
+    $node->save();
+    $this->assertFalse($local_task_creation_url->access($this->user));
+
+    $node->set('moderation_state', 'request_validation');
+    $node->save();
+    $this->assertFalse($local_task_creation_url->access($this->user));
+
+    // Navigate to the translation overview page and assert we don't have a link
+    // to start a translation.
+    $this->drupalGet($node->toUrl('drupal:content-translation-overview'));
+    // No link for regular Drupal core translation creation.
+    $this->assertSession()->linkNotExists('Add');
+    // No link for the local translation.
+    $this->assertSession()->linkNotExists('Translate locally');
+
+    $node->set('moderation_state', 'validated');
+    $node->save();
+    $this->assertTrue($local_task_creation_url->access($this->user));
+
+    $this->drupalGet($node->toUrl('drupal:content-translation-overview'));
+    $this->assertSession()->linkNotExists('Add');
+    $this->assertSession()->linkExists('Translate locally');
+
+    $node->set('moderation_state', 'published');
+    $node->save();
+    $this->assertTrue($local_task_creation_url->access($this->user));
+
+    $this->drupalGet($node->toUrl('drupal:content-translation-overview'));
+    $this->assertSession()->linkNotExists('Add');
+    $this->assertSession()->linkExists('Translate locally');
+
+    // If we start a new draft, then we block access to creating a new
+    // translation until the content is validated again.
+    $node->set('moderation_state', 'draft');
+    $node->save();
+    $this->assertFalse($local_task_creation_url->access($this->user));
+  }
+
+  /**
+   * Tests the creation of new translations.
+   */
+  public function testTranslationCreation(): void {
+    /** @var \Drupal\node\NodeStorageInterface $node_storage */
+    $node_storage = $this->entityTypeManager->getStorage('node');
+
+    /** @var \Drupal\node\NodeInterface $node */
+    $node = $node_storage->create([
+      'type' => 'page',
+      'title' => 'My node',
+      'moderation_state' => 'draft',
+    ]);
+    $node->save();
+    $this->moderateNode($node, 'validated');
+
+    // At this point, we expect to have 4 revisions of the node.
+    $revision_ids = $node_storage->revisionIds($node);
+    $this->assertCount(4, $revision_ids);
+
+    // Create a local translation task.
+    $this->drupalGet(Url::fromRoute('oe_translation.permission_translator.create_local_task', [
+      'entity' => $node->id(),
+      'source' => 'en',
+      'target' => 'fr',
+      'entity_type' => 'node',
+    ]));
+    $this->assertSession()->elementContains('css', '#edit-title0value-translation', 'My node');
+
+    // At this point the job item and local task have been created for the
+    // translation and they should reference the last revision of the node, that
+    // of the validated revision.
+    $job_items = $this->entityTypeManager->getStorage('tmgmt_job_item')->loadByProperties(['item_rid' => $node->getRevisionId()]);
+    $this->assertCount(1, $job_items);
+
+    // Publish the node before finalizing the translation.
+    $this->moderateNode($node, 'published');
+    $revision_ids = $node_storage->revisionIds($node);
+    $this->assertCount(5, $revision_ids);
+
+    // Finalize the translation and check that the translation got saved onto
+    // the published version rather than the validated one where it actually
+    // got started.
+    $values = [
+      'title|0|value[translation]' => 'My node FR',
+    ];
+    // It should be the first local task item created so we use the ID 1.
+    $url = Url::fromRoute('entity.tmgmt_local_task_item.canonical', ['tmgmt_local_task_item' => 1]);
+    $this->drupalPostForm($url, $values, t('Save and complete translation'));
+    $node_storage->resetCache();
+    /** @var \Drupal\node\NodeInterface[] $revisions */
+    $revisions = $node_storage->loadMultipleRevisions($revision_ids);
+    foreach ($revisions as $revision) {
+      if ($revision->get('moderation_state')->value === 'published') {
+        $this->assertTrue($revision->hasTranslation('fr'), 'The published node does not have a translation');
+        continue;
+      }
+
+      $this->assertFalse($revision->hasTranslation('fr'), sprintf('The %s node has a translation and it shouldn\'t', $revision->get('moderation_state')->value));
+    }
+
+    // Start a new draft from the latest published node and validate it.
+    $node = $node_storage->load($node->id());
+    $node->set('title', 'My node 2');
+    $node->set('moderation_state', 'draft');
+    $node->save();
+    $revision_ids = $node_storage->revisionIds($node);
+    $this->assertCount(6, $revision_ids);
+    $this->moderateNode($node, 'validated');
+    $revision_ids = $node_storage->revisionIds($node);
+    $this->assertCount(9, $revision_ids);
+    // Assert that the latest revision that was just validated is the correct
+    // version and inherited the translation from the previous version.
+    /** @var \Drupal\node\NodeInterface $validated_node */
+    $validated_node = $node_storage->loadRevision($node_storage->getLatestRevisionId($node->id()));
+    $this->assertEquals('2', $validated_node->get('version')->major);
+    $this->assertEquals('0', $validated_node->get('version')->minor);
+    $this->assertEquals('My node FR', $validated_node->getTranslation('fr')->label());
+
+    // Create a new local translation task.
+    $this->drupalGet(Url::fromRoute('oe_translation.permission_translator.create_local_task', [
+      'entity' => $node->id(),
+      'source' => 'en',
+      'target' => 'fr',
+      'entity_type' => 'node',
+    ]));
+
+    // The default translation value comes from the previous version
+    // translation.
+    $this->assertSession()->elementContains('css', '#edit-title0value-translation', 'My node FR');
+
+    // Assert that the new job item got created and it has the revision ID of
+    // the validated node.
+    $job_items = $this->entityTypeManager->getStorage('tmgmt_job_item')->loadByProperties(['item_rid' => $validated_node->getRevisionId()]);
+    $this->assertCount(1, $job_items);
+
+    // Publish the node before finalizing the translation.
+    $this->moderateNode($node, 'published');
+    $revision_ids = $node_storage->revisionIds($node);
+    $this->assertCount(10, $revision_ids);
+
+    // Finalize the translation and check that the translation got saved onto
+    // the published version rather than the validated one where it actually
+    // got started.
+    $values = [
+      'title|0|value[translation]' => 'My node FR 2',
+    ];
+    // It should be the second local task item created so we use the ID 2.
+    $url = Url::fromRoute('entity.tmgmt_local_task_item.canonical', ['tmgmt_local_task_item' => 2]);
+    $this->drupalPostForm($url, $values, t('Save and complete translation'));
+    $node_storage->resetCache();
+    $validated_node = $node_storage->loadRevision($validated_node->getRevisionId());
+    // The second validated revision should have the old FR translation.
+    $this->assertEquals('My node FR', $validated_node->getTranslation('fr')->label());
+    $node = $node_storage->load($node->id());
+    // The new (current) published revision should have the new FR translation.
+    $this->assertEquals('My node FR 2', $node->getTranslation('fr')->label());
+
+    // The previous published revisions have the old FR translation.
+    $revision_ids = $node_storage->revisionIds($node);
+    /** @var \Drupal\node\NodeInterface[] $revisions */
+    $revisions = $node_storage->loadMultipleRevisions($revision_ids);
+    foreach ($revisions as $revision) {
+      if ($revision->isPublished() && (int) $revision->get('version')->major === 1) {
+        $this->assertEquals('My node FR', $revision->getTranslation('fr')->label());
+        break;
+      }
+    }
+  }
+
+  /**
+   * Sends the node through the moderation states to reach the target.
+   *
+   * @param \Drupal\node\NodeInterface $node
+   *   The node.
+   * @param string $target_state
+   *   The target moderation state,.
+   */
+  protected function moderateNode(NodeInterface $node, string $target_state): void {
+    $states = [
+      'draft',
+      'needs_review',
+      'request_validation',
+      'validated',
+      'published',
+    ];
+
+    $current_state = $node->get('moderation_state')->value;
+    if ($current_state === $target_state) {
+      return;
+    }
+
+    $pos = array_search($current_state, $states);
+    foreach (array_slice($states, $pos + 1) as $new_state) {
+      $node->set('moderation_state', $new_state);
+      $node->save();
+      if ($new_state === $target_state) {
+        break;
+      }
+    }
+  }
+
+}

--- a/modules/oe_editorial_entity_version/oe_editorial_entity_version.install
+++ b/modules/oe_editorial_entity_version/oe_editorial_entity_version.install
@@ -59,7 +59,7 @@ function oe_editorial_entity_version_install(): void {
   }
 
   // Get the bundles the workflow is associated with.
-  $bundles = $corporate_workflow->get('type_settings')['entity_types']['node'];
+  $bundles = isset($corporate_workflow->get('type_settings')['entity_types']['node']) ? $corporate_workflow->get('type_settings')['entity_types']['node'] : [];
   if (!$bundles) {
     return;
   }

--- a/modules/oe_editorial_workflow_demo/config/install/language.content_settings.node.oe_workflow_demo.yml
+++ b/modules/oe_editorial_workflow_demo/config/install/language.content_settings.node.oe_workflow_demo.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.oe_workflow_demo
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '1'
+id: node.oe_workflow_demo
+target_entity_type_id: node
+target_bundle: oe_workflow_demo
+default_langcode: site_default
+language_alterable: true

--- a/modules/oe_editorial_workflow_demo/config/install/language.entity.fr.yml
+++ b/modules/oe_editorial_workflow_demo/config/install/language.entity.fr.yml
@@ -1,0 +1,8 @@
+langcode: en
+status: true
+dependencies: {  }
+id: fr
+label: French
+direction: ltr
+weight: 1
+locked: false

--- a/modules/oe_editorial_workflow_demo/config/install/language.entity.it.yml
+++ b/modules/oe_editorial_workflow_demo/config/install/language.entity.it.yml
@@ -1,0 +1,8 @@
+langcode: en
+status: true
+dependencies: {  }
+id: it
+label: Italian
+direction: ltr
+weight: 2
+locked: false

--- a/modules/oe_editorial_workflow_demo/oe_editorial_workflow_demo.info.yml
+++ b/modules/oe_editorial_workflow_demo/oe_editorial_workflow_demo.info.yml
@@ -6,7 +6,12 @@ core: 8.x
 
 dependencies:
   - oe_editorial_entity_version:oe_editorial_entity_version
+  - drupal:content_translation
+  - drupal:language
 
 config_devel:
   install:
     - node.type.oe_workflow_demo
+    - language.content_settings.node.oe_workflow_demo.yml
+    - language.entity.fr.yml
+    - language.entity.it.yml

--- a/modules/oe_editorial_workflow_demo/oe_editorial_workflow_demo.install
+++ b/modules/oe_editorial_workflow_demo/oe_editorial_workflow_demo.install
@@ -21,7 +21,7 @@ function oe_editorial_workflow_demo_install(): void {
   // Add entity version field to corporate workflow bundles.
   /** @var \Drupal\workflows\WorkflowInterface $corporate_workflow */
   $corporate_workflow = \Drupal::entityTypeManager()->getStorage('workflow')->load('oe_corporate_workflow');
-  $bundles = $corporate_workflow->get('type_settings')['entity_types']['node'];
+  $bundles = isset($corporate_workflow->get('type_settings')['entity_types']['node']) ? $corporate_workflow->get('type_settings')['entity_types']['node'] : [];
   if (!$bundles) {
     return;
   }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,7 +10,7 @@
   <testsuites>
     <testsuite>
       <directory>./tests/</directory>
-      <directory>./modules/**/tests/</directory>
+      <directory>./modules/*/modules/*/tests/</directory>
     </testsuite>
   </testsuites>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,6 +10,7 @@
   <testsuites>
     <testsuite>
       <directory>./tests/</directory>
+      <directory>./modules/**/tests/</directory>
     </testsuite>
   </testsuites>
 </phpunit>


### PR DESCRIPTION
A few things happen in this PR:

* We create a module that connects oe_translation to the corporate workflow
* We merge the oe_translation Translator role with that provided by the editorial module
* We keep the publication status of translations and the source in sync
* We hide the content moderation form from the translation preview page
* We override the core revision creation mechanism to allow for translations to be inherited from the last revision and not only the last default revision
* We save the incoming translations on the newest major revision of the version where it the translation was requested. For example, if requested in Validated and it gets published in the meantime, it gets saved in the Published. But not in any of potential future revisions that start new minor versions.
* We prevent translations before content reaches Validated state