### PR TITLE
Openeuropa 2454: Update translator name.

### DIFF
--- a/modules/oe_editorial_corporate_workflow/config/install/user.role.oe_translator.yml
+++ b/modules/oe_editorial_corporate_workflow/config/install/user.role.oe_translator.yml
@@ -2,7 +2,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: oe_translator
-label: Translator
+label: Translate content
 weight: 5
 is_admin: null
 permissions:

--- a/modules/oe_editorial_corporate_workflow/oe_editorial_corporate_workflow.post_update.php
+++ b/modules/oe_editorial_corporate_workflow/oe_editorial_corporate_workflow.post_update.php
@@ -18,3 +18,14 @@ function oe_editorial_corporate_workflow_post_update_set_validator_permission(ar
     ->grantPermission('use oe_corporate_workflow transition validated_to_draft')
     ->save();
 }
+
+/**
+ * Adapts translator role name.
+ */
+function oe_editorial_corporate_workflow_post_update_00001(): void {
+  \Drupal::entityTypeManager()
+    ->getStorage('user_role')
+    ->load('oe_translator')
+    ->set('label', 'Translate content')
+    ->save();
+}

--- a/tests/features/content_version.feature
+++ b/tests/features/content_version.feature
@@ -5,8 +5,8 @@ Feature: Content version
 
   Scenario: The version field value changes based on the configured transitions.
     Given users:
-      | name        | roles                                   |
-      | author_user | Author, Reviewer, Validator, Translator |
+      | name        | roles                                          |
+      | author_user | Author, Reviewer, Validator, Translate content |
     And "oe_workflow_demo" content:
       # When the node is created, it already gets the version 0.1.0 as default.
       | title         | moderation_state | author      |

--- a/tests/features/editorial_workflow.feature
+++ b/tests/features/editorial_workflow.feature
@@ -235,8 +235,8 @@ Feature: Corporate editorial workflow
 
   Scenario: Permission to delete content is not given to any editorial role.
     Given users:
-      | name        | roles                                   |
-      | author_user | Author, Reviewer, Validator, Translator |
+      | name        | roles                                          |
+      | author_user | Author, Reviewer, Validator, Translate content |
     And "oe_workflow_demo" content:
       | title         | moderation_state | author      |
       | Workflow node | draft            | author_user |


### PR DESCRIPTION
## OPENEUROPA-2454

### Description

Update translator name

### Change log

- Added:
- Changed: translator name from "Translator" to "Translate content"

### Commands

```sh
drush updb

```

