### PR TITLE
ISSUE-59: Remove permissions referrencing non-existent transitions.

### DIFF
--- a/modules/oe_editorial_corporate_workflow/config/install/user.role.oe_reviewer.yml
+++ b/modules/oe_editorial_corporate_workflow/config/install/user.role.oe_reviewer.yml
@@ -8,7 +8,6 @@ is_admin: null
 permissions:
   - 'access content overview'
   - 'use oe_corporate_workflow transition needs_review_to_draft'
-  - 'use oe_corporate_workflow transition needs_review_to_needs_review'
   - 'use oe_corporate_workflow transition needs_review_to_request_validation'
   - 'view all revisions'
   - 'view any unpublished content'

--- a/modules/oe_editorial_corporate_workflow/config/install/user.role.oe_validator.yml
+++ b/modules/oe_editorial_corporate_workflow/config/install/user.role.oe_validator.yml
@@ -9,7 +9,6 @@ permissions:
   - 'access content overview'
   - 'use oe_corporate_workflow transition request_validation_to_draft'
   - 'use oe_corporate_workflow transition request_validation_to_needs_review'
-  - 'use oe_corporate_workflow transition request_validation_to_request_validation'
   - 'use oe_corporate_workflow transition request_validation_to_validated'
   - 'use oe_corporate_workflow transition validated_to_draft'
   - 'use oe_corporate_workflow transition validated_to_published'

--- a/modules/oe_editorial_corporate_workflow/config/install/user.role.oe_validator.yml
+++ b/modules/oe_editorial_corporate_workflow/config/install/user.role.oe_validator.yml
@@ -7,14 +7,12 @@ weight: 4
 is_admin: null
 permissions:
   - 'access content overview'
-  - 'use oe_corporate_workflow transition published_to_published'
   - 'use oe_corporate_workflow transition request_validation_to_draft'
   - 'use oe_corporate_workflow transition request_validation_to_needs_review'
   - 'use oe_corporate_workflow transition request_validation_to_request_validation'
   - 'use oe_corporate_workflow transition request_validation_to_validated'
   - 'use oe_corporate_workflow transition validated_to_draft'
   - 'use oe_corporate_workflow transition validated_to_published'
-  - 'use oe_corporate_workflow transition validated_to_validated'
   - 'use oe_corporate_workflow transition published_to_archived'
   - 'use oe_corporate_workflow transition published_to_expired'
   - 'view all revisions'


### PR DESCRIPTION
## OPENEUROPA-ISSUE-59

### Description

Removed permission assignments referencing non-existent transitions.

### Change log

- Changed: 
./modules/oe_editorial_corporate_workflow/config/install/user.role.oe_reviewer.yml
./modules/oe_editorial_corporate_workflow/config/install/user.role.oe_validator.yml


