### PR TITLE
OPENEUROPA-0000: Prepare release 1.5.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,31 +1,58 @@
-# Change Log
+# Changelog
+
+## [1.5.0](https://github.com/openeuropa/oe_editorial/tree/1.5.0) (2020-04-29)
+
+[Full Changelog](https://github.com/openeuropa/oe_editorial/compare/1.4.0...1.5.0)
+
+**Merged pull requests:**
+
+- OPENEUROPA-3012: Poetry translation updates. [\#73](https://github.com/openeuropa/oe_editorial/pull/73) ([upchuk](https://github.com/upchuk))
+- OPENEUROPA-0000: Ensure the entity type has a canonical route before adding the unpublish route. [\#72](https://github.com/openeuropa/oe_editorial/pull/72) ([upchuk](https://github.com/upchuk))
+- OPENEUROPA-2969: Display the major version of the node where the translation request originates from. [\#70](https://github.com/openeuropa/oe_editorial/pull/70) ([22Alexandra](https://github.com/22Alexandra))
 
 ## [1.4.0](https://github.com/openeuropa/oe_editorial/tree/1.4.0) (2020-04-08)
+
 [Full Changelog](https://github.com/openeuropa/oe_editorial/compare/1.3.1...1.4.0)
 
 **Merged pull requests:**
 
+- OPENEUROPA-2954: Release 1.4.0. [\#71](https://github.com/openeuropa/oe_editorial/pull/71) ([nagyad](https://github.com/nagyad))
 - OPENEUROPA-2943: Update composer.json. [\#69](https://github.com/openeuropa/oe_editorial/pull/69) ([sergepavle](https://github.com/sergepavle))
 - Allowing to unpublish content from any moderation state [\#68](https://github.com/openeuropa/oe_editorial/pull/68) ([upchuk](https://github.com/upchuk))
+- Rebasing the Unpublish epic. [\#67](https://github.com/openeuropa/oe_editorial/pull/67) ([upchuk](https://github.com/upchuk))
 - OPENEUROPA-0000: Use drupal/core instead of drupal/core-recommended. [\#66](https://github.com/openeuropa/oe_editorial/pull/66) ([22Alexandra](https://github.com/22Alexandra))
+- OPENEUROPA-2289: Allow to unpublish a node regardless of workflow state. [\#65](https://github.com/openeuropa/oe_editorial/pull/65) ([imanoleguskiza](https://github.com/imanoleguskiza))
 - OPENEUROPA-2941: Update php version. [\#64](https://github.com/openeuropa/oe_editorial/pull/64) ([sergepavle](https://github.com/sergepavle))
+- OPENEUROPA-2824: Content entity form used for the unpublished form. [\#63](https://github.com/openeuropa/oe_editorial/pull/63) ([upchuk](https://github.com/upchuk))
+- Updates from the master branch. [\#62](https://github.com/openeuropa/oe_editorial/pull/62) ([upchuk](https://github.com/upchuk))
 - OPENEUROPA-3018: Ensure Drupal 8.8 compatibility [\#61](https://github.com/openeuropa/oe_editorial/pull/61) ([upchuk](https://github.com/upchuk))
+- OPENEUROPA-2721: Add unpublish functionality. [\#57](https://github.com/openeuropa/oe_editorial/pull/57) ([imanoleguskiza](https://github.com/imanoleguskiza))
 
-## [1.3.1](https://github.com/openeuropa/oe_editorial/tree/1.3.1) (2020-03-02)
+## [1.3.1](https://github.com/openeuropa/oe_editorial/tree/1.3.1) (2020-03-03)
+
 [Full Changelog](https://github.com/openeuropa/oe_editorial/compare/1.3.0...1.3.1)
 
+**Closed issues:**
+
+- The hook oe\_editorial\_corporate\_workflow\_post\_update\_00001\(\) fails if the module oe\_translation is not enabled [\#51](https://github.com/openeuropa/oe_editorial/issues/51)
+
 **Merged pull requests:**
 
+- Release-1.3.1: Update changelog. [\#58](https://github.com/openeuropa/oe_editorial/pull/58) ([nagyad](https://github.com/nagyad))
 - OPENEUROPA-2754: Remove permissions for reverting/deleting revisions. [\#54](https://github.com/openeuropa/oe_editorial/pull/54) ([sergepavle](https://github.com/sergepavle))
 
-## [1.3.0](https://github.com/openeuropa/oe_editorial/tree/1.3.0) (2020-01-30)
-[Full Changelog](https://github.com/openeuropa/oe_editorial/compare/1.2.0...1.3.0)
+## [1.3.0](https://github.com/openeuropa/oe_editorial/tree/1.3.0) (2020-01-31)
+
+[Full Changelog](https://github.com/openeuropa/oe_editorial/compare/1.2.1...1.3.0)
 
 **Merged pull requests:**
 
+- OPENEUROPA-0000: Bringing update path hotfix to the latest release. [\#56](https://github.com/openeuropa/oe_editorial/pull/56) ([nagyad](https://github.com/nagyad))
+- OPENEUROPA-1766: Release 1.3.0. [\#53](https://github.com/openeuropa/oe_editorial/pull/53) ([dxvargas](https://github.com/dxvargas))
 - OPENEUROPA-2252: Poetry translation update. [\#49](https://github.com/openeuropa/oe_editorial/pull/49) ([upchuk](https://github.com/upchuk))
 
 ## [1.2.1](https://github.com/openeuropa/oe_editorial/tree/1.2.1) (2020-01-31)
+
 [Full Changelog](https://github.com/openeuropa/oe_editorial/compare/1.2.0...1.2.1)
 
 **Merged pull requests:**
@@ -33,6 +60,7 @@
 - OPENEUROPA-0000: Fixing update path of role label. [\#55](https://github.com/openeuropa/oe_editorial/pull/55) ([nagyad](https://github.com/nagyad))
 
 ## [1.2.0](https://github.com/openeuropa/oe_editorial/tree/1.2.0) (2020-01-13)
+
 [Full Changelog](https://github.com/openeuropa/oe_editorial/compare/1.1.1...1.2.0)
 
 **Merged pull requests:**
@@ -41,6 +69,7 @@
 - OPENEUROPA-2503: Align the translator role between components. [\#47](https://github.com/openeuropa/oe_editorial/pull/47) ([nagyad](https://github.com/nagyad))
 
 ## [1.1.1](https://github.com/openeuropa/oe_editorial/tree/1.1.1) (2019-12-02)
+
 [Full Changelog](https://github.com/openeuropa/oe_editorial/compare/1.1.0...1.1.1)
 
 **Merged pull requests:**
@@ -52,15 +81,16 @@
 - OPENEUROPA-2258: Use PHP 7.2 in drone and docker image. [\#42](https://github.com/openeuropa/oe_editorial/pull/42) ([dxvargas](https://github.com/dxvargas))
 
 ## [1.1.0](https://github.com/openeuropa/oe_editorial/tree/1.1.0) (2019-08-12)
+
 [Full Changelog](https://github.com/openeuropa/oe_editorial/compare/1.0.0...1.1.0)
 
 **Merged pull requests:**
 
-- Release-1.1.0 [\#41](https://github.com/openeuropa/oe_editorial/pull/41) ([nagyad](https://github.com/nagyad))
 -  OPENEUROPA-2076: Use entity\_version from drupal repo. [\#40](https://github.com/openeuropa/oe_editorial/pull/40) ([nagyad](https://github.com/nagyad))
 - OPENEUROPA-2041: Change url of textarea help link. [\#36](https://github.com/openeuropa/oe_editorial/pull/36) ([imanoleguskiza](https://github.com/imanoleguskiza))
 
 ## [1.0.0](https://github.com/openeuropa/oe_editorial/tree/1.0.0) (2019-07-24)
+
 [Full Changelog](https://github.com/openeuropa/oe_editorial/compare/1.0.0-beta4...1.0.0)
 
 **Closed issues:**
@@ -69,10 +99,12 @@
 
 **Merged pull requests:**
 
+- Release-1.1.0 [\#41](https://github.com/openeuropa/oe_editorial/pull/41) ([nagyad](https://github.com/nagyad))
 - Release 1.0.0: Update changelog. [\#39](https://github.com/openeuropa/oe_editorial/pull/39) ([dxvargas](https://github.com/dxvargas))
 - OPENEUROPA-2053: Corporate workflow translation. [\#38](https://github.com/openeuropa/oe_editorial/pull/38) ([upchuk](https://github.com/upchuk))
 
 ## [1.0.0-beta4](https://github.com/openeuropa/oe_editorial/tree/1.0.0-beta4) (2019-07-10)
+
 [Full Changelog](https://github.com/openeuropa/oe_editorial/compare/1.0.0-beta3...1.0.0-beta4)
 
 **Merged pull requests:**
@@ -81,6 +113,7 @@
 - OPENEUROPA-2037: Integrate the new config setting entity version. [\#34](https://github.com/openeuropa/oe_editorial/pull/34) ([nagyad](https://github.com/nagyad))
 
 ## [1.0.0-beta3](https://github.com/openeuropa/oe_editorial/tree/1.0.0-beta3) (2019-07-02)
+
 [Full Changelog](https://github.com/openeuropa/oe_editorial/compare/1.0.0-beta2...1.0.0-beta3)
 
 **Merged pull requests:**
@@ -89,6 +122,7 @@
 - OPENEUROPA-1915: Integrate entity\_versions module in oe\_editorial [\#30](https://github.com/openeuropa/oe_editorial/pull/30) ([nagyad](https://github.com/nagyad))
 
 ## [1.0.0-beta2](https://github.com/openeuropa/oe_editorial/tree/1.0.0-beta2) (2019-06-25)
+
 [Full Changelog](https://github.com/openeuropa/oe_editorial/compare/1.0.0-beta1...1.0.0-beta2)
 
 **Merged pull requests:**
@@ -98,6 +132,7 @@
 - OPENEUROPA-1770: Shortcuts on workflow block on node view page [\#23](https://github.com/openeuropa/oe_editorial/pull/23) ([nagyad](https://github.com/nagyad))
 
 ## [1.0.0-beta1](https://github.com/openeuropa/oe_editorial/tree/1.0.0-beta1) (2019-05-15)
+
 [Full Changelog](https://github.com/openeuropa/oe_editorial/compare/0.2.0...1.0.0-beta1)
 
 **Closed issues:**
@@ -109,6 +144,7 @@
 - OPENEUROPA-1864: Update Changelog for release 1.0.0-beta1. [\#26](https://github.com/openeuropa/oe_editorial/pull/26) ([sergepavle](https://github.com/sergepavle))
 
 ## [0.2.0](https://github.com/openeuropa/oe_editorial/tree/0.2.0) (2019-05-07)
+
 [Full Changelog](https://github.com/openeuropa/oe_editorial/compare/0.1.1...0.2.0)
 
 **Merged pull requests:**
@@ -117,6 +153,7 @@
 - OPENEUROPA-1813: Upgrade to 8.7 [\#22](https://github.com/openeuropa/oe_editorial/pull/22) ([upchuk](https://github.com/upchuk))
 
 ## [0.1.1](https://github.com/openeuropa/oe_editorial/tree/0.1.1) (2019-04-26)
+
 [Full Changelog](https://github.com/openeuropa/oe_editorial/compare/0.1.0...0.1.1)
 
 **Merged pull requests:**
@@ -125,6 +162,9 @@
 - Fixing the menu local task alter moderation check. [\#20](https://github.com/openeuropa/oe_editorial/pull/20) ([upchuk](https://github.com/upchuk))
 
 ## [0.1.0](https://github.com/openeuropa/oe_editorial/tree/0.1.0) (2019-04-25)
+
+[Full Changelog](https://github.com/openeuropa/oe_editorial/compare/3bb8c5bd4a121aa2a656b1b76db70ba9f9cb72ad...0.1.0)
+
 **Merged pull requests:**
 
 - Update CHANGELOG.md for release 0.1.0. [\#19](https://github.com/openeuropa/oe_editorial/pull/19) ([ademarco](https://github.com/ademarco))
@@ -149,4 +189,4 @@
 
 
 
-\* *This Change Log was automatically generated by [github_changelog_generator](https://github.com/skywinder/Github-Changelog-Generator)*
+\* *This Changelog was automatically generated by [github_changelog_generator](https://github.com/github-changelog-generator/github-changelog-generator)*


### PR DESCRIPTION
## OPENEUROPA
### Description

Prepare release 1.5.0.

### Change log

- Added:
- Changed: Update changelog for 1.5.0
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

