### PR TITLE
OPENEUROPA-0000: Update minimum oe_paragraph version.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "drupal/drupal-extension": "~4.0",
         "drupal/entity_version": "1.x-dev",
         "drupal/address": "^1.8",
-        "openeuropa/oe_paragraphs": "~1.4.0",
+        "openeuropa/oe_paragraphs": "~1.6.0",
         "drush/drush": "~9.0@stable",
         "ec-europa/oe-poetry-client": "dev-master",
         "guzzlehttp/guzzle": "^6.3",


### PR DESCRIPTION
## OPENEUROPA

### Description

Update minimum oe_paragraph version to avoid failing builds.
### Change log

- Added:
- Changed: Updated minimum oe_paragraphs version to 1.6.0
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

