### PR TITLE
EWPP-2619: Corporate workflow bug fixes.

### DIFF
--- a/modules/oe_editorial_corporate_workflow/modules/oe_editorial_corporate_workflow_translation/oe_editorial_corporate_workflow_translation.module
+++ b/modules/oe_editorial_corporate_workflow/modules/oe_editorial_corporate_workflow_translation/oe_editorial_corporate_workflow_translation.module
@@ -48,6 +48,13 @@ function oe_editorial_corporate_workflow_translation_node_presave(EntityInterfac
       $entity->set('status', $source->get('status')->value);
     }
 
+    // We need to do the same for the moderation state.
+    $translation_state = $entity->get('moderation_state')->value;
+    $untranslated_state = $entity->getUntranslated()->get('moderation_state')->value;
+    if ($translation_state !== $entity->getUntranslated()->get('moderation_state')->value) {
+      $entity->set('moderation_state', $untranslated_state);
+    }
+
     return;
   }
 


### PR DESCRIPTION
This PR fixes the following:

* Mitigates a case in which, by some chance, the moderation state entity is missing translations which causes the following: upon saving a new translation onto the node that is in validated state, because the moderation state entity is missing the translation in that language that says "validated" as well, it will cause the node to switch to draft because the moderation state entity translation for that language is missing so Drupal will set the default, draft value.